### PR TITLE
Added stochastic selection of markets

### DIFF
--- a/R/GeoLift.R
+++ b/R/GeoLift.R
@@ -1158,6 +1158,48 @@ MarketSelection <- function(data,
 }
 
 
+#' Stochastic Market Selector.
+#'
+#' @description
+#'
+#' \code{build_stochastic_matrix} selects the markets to be tested
+#' by randomly sampling from the \code{similarity_matrix}.
+#' It gets groups of 2 elements and samples one of them. It repeats
+#' this process until the \code{treatment_size} is equal to the sample.
+#'
+#' @param treatment_size Is the amount of location units within the
+#' treatment group.
+#' @param similarit_matrix Matrix that sorts each location in terms 
+#' of descending correlation.
+#'
+#' @return
+#' Returns a matrix of sampled combinations of treatments.  
+#' Each row represents a different treatment.
+#'
+#' @export
+stochastic_market_selector <- function(
+  treatment_size,
+  similarity_matrix
+){
+  if (treatment_size > 0.5*ncol(similarity_matrix)){
+    stop(glue(
+      "Treatment size ({treatment_size}) should be <= to half the amount of units: {ncol(similarity_matrix)}"))
+  }
+  sample_size <- round(ncol(similarity_matrix) / treatment_size)
+  sample_matrix <- c()
+  i <- 0
+  while ( (i / 2) < treatment_size){
+    sampled_number <- sample(1:2, 1) + i
+    sample_matrix <- cbind(sample_matrix, similarity_matrix[, sampled_number])
+    i <- i + 2
+  }
+  for (row in 1:nrow(sample_matrix)){ #Sort rows.
+    sample_matrix[row,] <- sort(sample_matrix[row,])
+  }
+  return(unique(sample_matrix))
+}
+
+
 #' Power calculations for unknown test market locations, number of
 #' test markets, and test duration.
 #'
@@ -1292,7 +1334,7 @@ GeoLiftPower.search <- function(data,
   }
 
   for (n in N){
-    BestMarkets_aux <- BestMarkets[,1:n]
+    BestMarkets_aux <- stochastic_market_selector(n, BestMarkets)
     for (test in 1:nrow(BestMarkets_aux)){ #iterate through lift %
       for (tp in treatment_periods){ #lifts
 
@@ -1537,7 +1579,7 @@ GeoLiftPowerFinder <- function(data,
 
 
   for (n in N){
-    BestMarkets_aux <- BestMarkets[,1:n]
+    BestMarkets_aux <- stochastic_market_selector(n, BestMarkets)
     for (es in effect_size){ #iterate through lift %
       for (tp in treatment_periods){ #lifts
 

--- a/R/GeoLift.R
+++ b/R/GeoLift.R
@@ -1183,7 +1183,7 @@ stochastic_market_selector <- function(
   run_stochastic_process=FALSE
 ){
   if (!run_stochastic_process){
-    return(similarity_matrix)
+    return(similarity_matrix[, 1:treatment_size])
   } else {
     if (treatment_size > 0.5*ncol(similarity_matrix)){
       stop(glue(

--- a/R/GeoLift.R
+++ b/R/GeoLift.R
@@ -1183,8 +1183,10 @@ stochastic_market_selector <- function(
   run_stochastic_process=FALSE
 ){
   if (!run_stochastic_process){
+    message("Deterministic setup with ", treatment_size, " locations in treatment.")
     return(similarity_matrix[, 1:treatment_size])
   } else {
+    message("Random setup with ", treatment_size, " locations in treatment.")
     if (treatment_size > 0.5*ncol(similarity_matrix)){
       stop(glue(
         "Treatment size ({treatment_size}) should be <= to half the amount of units: {ncol(similarity_matrix)}"))


### PR DESCRIPTION
- Randomly sample single element of a group of two correlated locations. 
- Move on to next group of two. Sample one of them.
- Repeat until the sample is the same size as the parameter treatment_size.

Tested in my Bento and it works.