### PR TITLE
escape dot as a separator

### DIFF
--- a/R/GeoLift.R
+++ b/R/GeoLift.R
@@ -117,7 +117,7 @@ GeoDataRead <- function(data,
   } else if(str_count(format, pattern = fixed("-")) > 0) {
     sep <- "-"
   } else if(str_count(format, pattern = fixed(".")) > 0) {
-    sep = "."
+    sep = "\\."
   } else {
     sep <- ""
   }


### PR DESCRIPTION
"." is a special character, so unless we escape it with "\\.", it will cause errors when the date format contains dots (for example "yyyy.mm.dd"