### PR TITLE
Make parallel errors more verbose

### DIFF
--- a/R/GeoLift.R
+++ b/R/GeoLift.R
@@ -749,7 +749,7 @@ GeoLiftPower <- function(data,
       if (parallel == TRUE){
         a <- foreach(sim = 1:(t_n - horizon + 1), #NEWCHANGE: Horizon = earliest start time for simulations
                      .combine=cbind,
-                     .errorhandling = 'remove') %dopar% {
+                     .errorhandling = 'stop') %dopar% {
                        pvalueCalc(
                          data = data,
                          sim = sim,
@@ -1094,7 +1094,7 @@ NumberLocations <- function(data,
     if (parallel == TRUE){
       a <- foreach(sim = 1:n_sim,
                    .combine=cbind,
-                   .errorhandling = 'remove') %dopar% {
+                   .errorhandling = 'stop') %dopar% {
                      pvalueCalc(
                        data = data,
                        sim = 1,
@@ -1483,7 +1483,7 @@ GeoLiftPower.search <- function(data,
         if (parallel == TRUE){
           a <- foreach(sim = 1:(t_n - horizon + 1), #NEWCHANGE: Horizon = earliest start time for simulations
                        .combine=cbind,
-                       .errorhandling = 'remove') %dopar% {
+                       .errorhandling = 'stop') %dopar% {
                          pvalueCalc(
                            data = data,
                            sim = sim,
@@ -1765,7 +1765,7 @@ GeoLiftPowerFinder <- function(data,
         if (parallel == TRUE){
           a <- foreach(test = 1:nrow(as.matrix(BestMarkets_aux)), #NEWCHANGE: Horizon = earliest start time for simulations
                        .combine=cbind,
-                       .errorhandling = 'remove') %dopar% {
+                       .errorhandling = 'stop') %dopar% {
                          pvalueCalc(
                            data = data,
                            sim = 1,


### PR DESCRIPTION
Changing all error handling from foreach parallelization to stop instead of remove.

Currently, the "remove" option allows for the algorithm to follow through if it has errors, removing all lines.  Problem with that is that it fails later on with the error "1:ncol(a) argument of length 0" because it has no output, since it removed all errors.

If we move it to "stop" the algorithm will fail before, and will output the reason why it failed.  Hence the change, it will make it easier to debug.